### PR TITLE
A typo in the distinct' quickcheck makes you test the old Course.State.d...

### DIFF
--- a/src/Course/StateT.hs
+++ b/src/Course/StateT.hs
@@ -159,7 +159,7 @@ putT =
 --
 -- /Tip:/ Use `filtering` and `State'` with a @Data.Set#Set@.
 --
--- prop> distinct xs == distinct (flatMap (\x -> x :. x :. Nil) xs)
+-- prop> distinct' xs == distinct' (flatMap (\x -> x :. x :. Nil) xs)
 distinct' ::
   (Ord a, Num a) =>
   List a


### PR DESCRIPTION
 A typo in the distinct' quickcheck makes you test the old Course.State.distinct version instead of the state' one we just did in StateT.
