### PR TITLE
Add extra tests for jsonString, jsonNumber, moveLeftN' and `instance Traversable ListZipper`

### DIFF
--- a/src/Course/JsonParser.hs
+++ b/src/Course/JsonParser.hs
@@ -88,6 +88,9 @@ toSpecialCharacter c =
 -- >>> parse jsonString "\" abc\""
 -- Result >< " abc"
 --
+-- >>> parse jsonString "\" abc\" "
+-- Result >< " abc"
+--
 -- >>> parse jsonString "\"abc\"def"
 -- Result >def< "abc"
 --
@@ -118,6 +121,9 @@ jsonString =
 -- /Tip:/ Use @readFloats@.
 --
 -- >>> parse jsonNumber "234"
+-- Result >< 234 % 1
+--
+-- >>> parse jsonNumber "234 "
 -- Result >< 234 % 1
 --
 -- >>> parse jsonNumber "-234"

--- a/src/Course/ListZipper.hs
+++ b/src/Course/ListZipper.hs
@@ -648,13 +648,17 @@ instance Comonad ListZipper where
     error "todo"
 
 -- | Implement the `Traversable` instance for `ListZipper`.
--- This implementation traverses a zipper while running some `Applicative` effect through the zipper.
+-- This implementation traverses a zipper from left to right while running
+-- some `Applicative` effect through the zipper.
 -- An effectful zipper is returned.
 --
 -- >>> traverse id (zipper [Full 1, Full 2, Full 3] (Full 4) [Full 5, Full 6, Full 7])
 -- Full [1,2,3] >4< [5,6,7]
 --
 -- >>> traverse id (zipper [Full 1, Full 2, Full 3] (Full 4) [Empty, Full 6, Full 7])
+-- Empty
+--
+-- >>> traverse id (zipper [error "traversing left values in wrong order", Empty] (error "traversing focus before left values") [Full 5, Full 6, Full 7])
 -- Empty
 instance Traversable ListZipper where
   traverse =

--- a/src/Course/ListZipper.hs
+++ b/src/Course/ListZipper.hs
@@ -417,6 +417,10 @@ moveRightN =
 --
 -- >>> moveLeftN' (-4) (zipper [5,4,3,2,1] 6 [7,8,9])
 -- Left 3
+--
+-- >>> rights <$> moveLeftN' 1 (zipper [3,2,error "moveLeftN' not sufficiently lazy"] 4 [5,6,7])
+-- Right [4,5,6,7]
+--
 moveLeftN' ::
   Int
   -> ListZipper a

--- a/src/Course/MoreParser.hs
+++ b/src/Course/MoreParser.hs
@@ -210,16 +210,16 @@ between =
 --
 -- /Tip:/ Use `between` and `charTok`.
 --
--- λ> parse (betweenCharTok '[' ']' character) "[a]"
+-- >>> parse (betweenCharTok '[' ']' character) "[a]"
 -- Result >< 'a'
 --
--- λ> isErrorResult (parse (betweenCharTok '[' ']' character) "[abc]")
+-- >>> isErrorResult (parse (betweenCharTok '[' ']' character) "[abc]")
 -- True
 --
--- λ> isErrorResult (parse (betweenCharTok '[' ']' character) "[abc")
+-- >>> isErrorResult (parse (betweenCharTok '[' ']' character) "[abc")
 -- True
 --
--- λ> isErrorResult (parse (betweenCharTok '[' ']' character) "abc]")
+-- >>> isErrorResult (parse (betweenCharTok '[' ']' character) "abc]")
 -- True
 betweenCharTok ::
   Char


### PR DESCRIPTION
Please let me know if you want me to split these up into separate pull requests.

The commit with name "Test laziness of moveLeftN'" depends on #111 for the Functor instance of (Either a). 
