### PR TITLE
Fixing Course.State#findM test

### DIFF
--- a/src/Course/State.hs
+++ b/src/Course/State.hs
@@ -133,7 +133,7 @@ put =
 -- >>> let p x = (\s -> (const $ pure (x == 'c')) =<< put (1+s)) =<< get in runState (findM p $ listh ['a'..'h']) 0
 -- (Full 'c',3)
 --
--- >>> let p x = (\s -> (const $ pure (x == 'i')) =<< put (1+s)) =<< get in runState (findM p $ listh ['a'..'h']) 8
+-- >>> let p x = (\s -> (const $ pure (x == 'i')) =<< put (1+s)) =<< get in runState (findM p $ listh ['a'..'h']) 0
 -- (Empty,8)
 findM ::
   Monad f =>


### PR DESCRIPTION
Reverting db0a8baa3c44106ef22ae42b816a74695a91cff3.
Course answers for this test also run with initial state of `0` rather than `8`:
https://github.com/tonymorris/course/blob/804aaf5aecd93d3def632f32245b2c0eb88a68a8/src/Course/State.hs#L138
