### PR TITLE
Include cmd for running FileIO example from share

### DIFF
--- a/src/Course/FileIO.hs
+++ b/src/Course/FileIO.hs
@@ -57,6 +57,10 @@ the contents of b
 ============ c.txt
 the contents of c
 
+
+* To run from ./share:
+
+share/ $ runhaskell -i../src ../src/Course/FileIO.hs files.txt
 -}
 
 -- /Tip:/ use @getArgs@ and @run@


### PR DESCRIPTION
./share includes the sample files described in the example.
Can run this from the command line by changing into `./share/` directory and 
calling `runhaskell` with `-i../src`.

Thanks to @ScottSedgwick for working this out.
