### PR TITLE
Remove deprecated Course.Monad issue reference

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -191,7 +191,7 @@ After this, the following progression of modules is recommended:
 * `Course.List`
 * `Course.Functor`
 * `Course.Applicative`
-* `Course.Monad` (please see [this issue](https://github.com/NICTA/course/issues/118))
+* `Course.Monad`
 * `Course.FileIO`
 * `Course.State`
 * `Course.StateT`


### PR DESCRIPTION
The reference to https://github.com/data61/fp-course/issues/118 was because `Course.Monad` used to lack exercises since  [Course.Bind contained all of them](https://github.com/data61/fp-course/commit/d63e28802abd768c2fb96496f0ad23066db5b9fc#diff-0a369498a5a8db3ac8fa606b544c9810R186). However, this was addressed in #164 and https://github.com/data61/fp-course/commit/9414bf23b5dd7987c13f0fa5a5631cb2b22a6bce#diff-93667008909f8bff80964d12b2d3473b.

This PR updates the readme to remove the deprecated remark.