### PR TITLE
Change references to NICTA in cabal files

### DIFF
--- a/course.cabal
+++ b/course.cabal
@@ -9,14 +9,15 @@ author:               James Earl Douglas <james@earldouglas.com>
 author:               Eric Torreborre <etorreborre@yahoo.com>
 maintainer:           Tony Morris
 copyright:            Copyright (C) 2010-2013 Tony Morris
-copyright:            Copyright (C) 2012-2015 National ICT Australia Limited 
+copyright:            Copyright (C) 2012-2015 National ICT Australia Limited
 copyright:            Copyright (C) 2012      James Earl Douglas
 copyright:            Copyright (C) 2012      Ben Sinclair
+copyright:            Copyright (C) 2016-2017 Data61
 synopsis:             Source code for a functional programming course
 category:             Education
 description:          Source code for a course in functional programming using Haskell
-homepage:             https://github.com/NICTA/course
-bug-reports:          https://github.com/NICTA/course/issues
+homepage:             https://github.com/data61/fp-course
+bug-reports:          https://github.com/data61/fp-course/issues
 cabal-version:        >= 1.10
 build-type:           Custom
 extra-source-files:   etc/CONTRIBUTORS,
@@ -25,7 +26,7 @@ extra-source-files:   etc/CONTRIBUTORS,
 
 source-repository     head
   type:               git
-  location:           git@github.com:NICTA/course.git
+  location:           git@github.com:data61/fp-course.git
 
 flag                  small_base
   description:        Choose the new, split-up base package.

--- a/projects/NetworkServer/haskell/network-server.cabal
+++ b/projects/NetworkServer/haskell/network-server.cabal
@@ -8,14 +8,14 @@ copyright:          Copyright (C) 2013 National ICT Australia Limited 2013
 synopsis:           A network server
 category:           Education
 description:        A network server
-homepage:           https://github.com/NICTA/course
-bug-reports:        https://github.com/NICTA/course/issues
+homepage:           https://github.com/data61/fp-course
+bug-reports:        https://github.com/data61/fp-course/issues
 cabal-version:      >= 1.10
 build-type:         Custom
 
 source-repository   head
   type:             git
-  location:         git@github.com:NICTA/course.git
+  location:         git@github.com:data61/fp-course.git
 
 flag                small_base
   description:      Choose the new, split-up base package.


### PR DESCRIPTION
A quick search in the repo didn't uncover any other references to NICTA that should be updated.