### PR TITLE
Reorder applicative tests

### DIFF
--- a/src/Course/Applicative.hs
+++ b/src/Course/Applicative.hs
@@ -33,24 +33,6 @@ class Functor f => Applicative f where
 
 infixl 4 <*>
 
--- | Witness that all things with (<*>) and pure also have (<$>).
---
--- >>> (+1) <$$> (ExactlyOne 2)
--- ExactlyOne 3
---
--- >>> (+1) <$$> Nil
--- []
---
--- >>> (+1) <$$> (1 :. 2 :. 3 :. Nil)
--- [2,3,4]
-(<$$>) ::
-  Applicative f =>
-  (a -> b)
-  -> f a
-  -> f b
-(<$$>) =
-  error "todo: Course.Applicative#(<$$>)"
-
 -- | Insert into ExactlyOne.
 --
 -- prop> pure x == ExactlyOne x
@@ -88,6 +70,24 @@ instance Applicative List where
     -> List b
   (<*>) =
     error "todo: Course.Apply (<*>)#instance List"
+
+-- | Witness that all things with (<*>) and pure also have (<$>).
+--
+-- >>> (+1) <$$> (ExactlyOne 2)
+-- ExactlyOne 3
+--
+-- >>> (+1) <$$> Nil
+-- []
+--
+-- >>> (+1) <$$> (1 :. 2 :. 3 :. Nil)
+-- [2,3,4]
+(<$$>) ::
+  Applicative f =>
+  (a -> b)
+  -> f a
+  -> f b
+(<$$>) =
+  (<*>) . pure
 
 -- | Insert into an Optional.
 --

--- a/test/Course/ApplicativeTest.hs
+++ b/test/Course/ApplicativeTest.hs
@@ -21,9 +21,9 @@ import           Course.Optional       (Optional (..))
 test_Applicative :: TestTree
 test_Applicative =
   testGroup "Applicative" [
-    haveFmapTest
-  , exactlyOneTest
+   exactlyOneTest
   , listTest
+  , haveFmapTest
   , optionalTest
   , functionTest
   , lift2Test
@@ -34,17 +34,6 @@ test_Applicative =
   , sequenceTest
   , replicateATest
   , filteringTest
-  ]
-
-haveFmapTest :: TestTree
-haveFmapTest =
-  testGroup "<$$>" [
-    testCase "ExactlyOne" $
-      (+ 1) <$$> (ExactlyOne 2) @?= ExactlyOne (3 :: Integer)
-  , testCase "empty List" $
-      (+ 1) <$$> Nil @?= Nil
-  , testCase "List" $
-      (+ 1) <$$> listh [1,2,3] @?= listh [2,3,4]
   ]
 
 exactlyOneTest :: TestTree
@@ -63,6 +52,17 @@ listTest =
       \x -> pure x == (x :. Nil :: List Integer)
   , testCase "<*>" $
       (+1) :. (*2) :. Nil <*> listh [1,2,3] @?= listh [2,3,4,2,4,6]
+  ]
+
+haveFmapTest :: TestTree
+haveFmapTest =
+  testGroup "<$$>" [
+    testCase "ExactlyOne" $
+      (+ 1) <$$> (ExactlyOne 2) @?= ExactlyOne (3 :: Integer)
+  , testCase "empty List" $
+      (+ 1) <$$> Nil @?= Nil
+  , testCase "List" $
+      (+ 1) <$$> listh [1,2,3] @?= listh [2,3,4]
   ]
 
 optionalTest :: TestTree


### PR DESCRIPTION
Move `(<$$>)` tests after we have the required instances for `ExactlyOne` and `List`.

Contributes to #213 