### PR TITLE
Fix Course/List.hs in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -194,7 +194,7 @@ tab completion, so you can save yourself some typing.
     > import Test.Tasty (defaultMain)
     >
     > -- Load the test module you'd like to run tests for
-    > :l test/Course.ListTest.hs
+    > :l test/Course/ListTest.hs
     >
     > -- Browse the contents of the loaded module - anything of type TestTree
     > -- may be run


### PR DESCRIPTION
Current version fails with error on GHCi, version 8.0.2 in the nix-shell
```
>> :l test/Course.ListTest.hs

<no location info>: error: can't find file: test/Course.ListTest.hs
Failed, modules loaded: none.
```

Due to `.` instead of `/`