### PR TITLE
List zipper tests

### DIFF
--- a/src/Course/ListZipper.hs
+++ b/src/Course/ListZipper.hs
@@ -75,6 +75,31 @@ instance Functor MaybeListZipper where
   (<$>) =
     error "todo: Course.ListZipper (<$>)#instance MaybeListZipper"
 
+-- | Convert the given zipper back to a list.
+--
+-- >>> toList <$> toOptional (fromList Nil)
+-- Empty
+--
+-- >>> toList (ListZipper Nil 1 (2:.3:.4:.Nil))
+-- [1,2,3,4]
+--
+-- >>> toList (ListZipper (3:.2:.1:.Nil) 4 (5:.6:.7:.Nil))
+-- [1,2,3,4,5,6,7]
+toList ::
+  ListZipper a
+  -> List a
+toList =
+  error "todo: Course.ListZipper#toList"
+
+-- | Convert the given (maybe) zipper back to a list.
+toListZ ::
+  MaybeListZipper a
+  -> List a
+toListZ IsNotZ =
+  Nil
+toListZ (IsZ z) =
+  toList z
+
 -- | Create a `MaybeListZipper` positioning the focus at the head.
 --
 -- ->>> fromList (1 :. 2 :. 3 :. Nil)
@@ -146,31 +171,6 @@ asMaybeZipper f (IsZ z) =
   -> MaybeListZipper a
 (-<<) =
   asMaybeZipper
-
--- | Convert the given zipper back to a list.
---
--- >>> toList <$> toOptional (fromList Nil)
--- Empty
---
--- >>> toList (ListZipper Nil 1 (2:.3:.4:.Nil))
--- [1,2,3,4]
---
--- >>> toList (ListZipper (3:.2:.1:.Nil) 4 (5:.6:.7:.Nil))
--- [1,2,3,4,5,6,7]
-toList ::
-  ListZipper a
-  -> List a
-toList =
-  error "todo: Course.ListZipper#toList"
-
--- | Convert the given (maybe) zipper back to a list.
-toListZ ::
-  MaybeListZipper a
-  -> List a
-toListZ IsNotZ =
-  Nil
-toListZ (IsZ z) =
-  toList z
 
 -- | Update the focus of the zipper with the given function on the current focus.
 --

--- a/test/Course/Gens.hs
+++ b/test/Course/Gens.hs
@@ -1,0 +1,49 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Course.Gens where
+
+import           Control.Applicative (liftA2, liftA3)
+import qualified Prelude             as P (fmap, foldr)
+import           Test.QuickCheck     (Arbitrary (..), Gen, Property, Testable,
+                                      forAllShrink)
+
+import           Course.Core
+import           Course.List         (List (..), hlist, listh)
+
+genList :: Arbitrary a => Gen (List a)
+genList = P.fmap ((P.foldr (:.) Nil) :: [a] -> List a) arbitrary
+
+shrinkList :: Arbitrary a => List a -> [List a]
+shrinkList =
+  P.fmap listh . shrink . hlist
+
+genIntegerList :: Gen (List Integer)
+genIntegerList = genList
+
+genIntegerAndList :: Gen (Integer, List Integer)
+genIntegerAndList = P.fmap (P.fmap listh) arbitrary
+
+shrinkIntegerAndList :: (Integer, List Integer) -> [(Integer, List Integer)]
+shrinkIntegerAndList = P.fmap (P.fmap listh) . shrink . P.fmap hlist
+
+genTwoLists :: Gen (List Integer, List Integer)
+genTwoLists = liftA2 (,) genIntegerList genIntegerList -- (arbitrary :: (List Integer, List Integer))
+
+shrinkTwoLists :: (List Integer, List Integer) -> [(List Integer, List Integer)]
+shrinkTwoLists (a,b) = P.fmap (\(as,bs) -> (listh as, listh bs)) $ shrink (hlist a, hlist b)
+
+genThreeLists :: Gen (List Integer, List Integer, List Integer)
+genThreeLists = liftA3 (,,) genIntegerList genIntegerList genIntegerList
+
+shrinkThreeLists :: (List Integer, List Integer, List Integer) -> [(List Integer, List Integer, List Integer)]
+shrinkThreeLists (a,b,c) = P.fmap (\(as,bs,cs) -> (listh as, listh bs, listh cs)) $ shrink (hlist a, hlist b, hlist c)
+
+genListOfLists :: Gen (List (List Integer))
+genListOfLists = P.fmap (P.fmap listh) (genList :: (Gen (List [Integer])))
+
+shrinkListOfLists :: Arbitrary a => List (List a) -> [List (List a)]
+shrinkListOfLists = P.fmap (P.fmap listh). shrinkList . P.fmap hlist
+
+forAllLists :: Testable prop => (List Integer -> prop) -> Property
+forAllLists = forAllShrink genIntegerList shrinkList

--- a/test/Course/Gens.hs
+++ b/test/Course/Gens.hs
@@ -47,3 +47,16 @@ shrinkListOfLists = P.fmap (P.fmap listh). shrinkList . P.fmap hlist
 
 forAllLists :: Testable prop => (List Integer -> prop) -> Property
 forAllLists = forAllShrink genIntegerList shrinkList
+
+-- (List Integer) and a Bool
+genListAndBool :: Gen (List Integer, Bool)
+genListAndBool = liftA2 (,) genIntegerList arbitrary
+
+shrinkListAndBool :: (List Integer, Bool) -> [(List Integer, Bool)]
+shrinkListAndBool (xs,b) = liftA2 (,) (shrinkList xs) (shrink b)
+
+forAllListsAndBool :: Testable prop
+                  => ((List Integer, Bool) -> prop)
+                  -> Property
+forAllListsAndBool =
+  forAllShrink genListAndBool shrinkListAndBool

--- a/test/Course/Gens.hs
+++ b/test/Course/Gens.hs
@@ -75,3 +75,17 @@ forAllListZipper :: Testable prop
                  -> Property
 forAllListZipper =
   forAllShrink genListZipper shrinkListZipper
+
+genListZipperWithInt :: Gen (ListZipper Integer, Int)
+genListZipperWithInt =
+  (,) P.<$> genListZipper P.<*> arbitrary
+
+shrinkListZipperWithInt :: (ListZipper Integer, Int) -> [(ListZipper Integer, Int)]
+shrinkListZipperWithInt (z, i) =
+  (,) P.<$> (shrinkListZipper z) P.<*> (shrink i)
+
+forAllListZipperWithInt :: Testable prop
+                        => ((ListZipper Integer, Int) -> prop)
+                        -> Property
+forAllListZipperWithInt =
+  forAllShrink genListZipperWithInt shrinkListZipperWithInt

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -11,8 +11,9 @@ import           Test.Tasty.QuickCheck (testProperty)
 import           Course.Core
 import           Course.Functor        ((<$>))
 import           Course.List           (List (..), isEmpty)
-import           Course.ListZipper     (MaybeListZipper (..), fromList, toList,
-                                        toListZ, toOptional, withFocus, zipper)
+import           Course.ListZipper     (MaybeListZipper (..), fromList,
+                                        setFocus, toList, toListZ, toOptional,
+                                        withFocus, zipper)
 import           Course.Optional       (Optional (Empty))
 
 import           Course.ListTest       (forAllLists)
@@ -26,6 +27,7 @@ test_ListZipper =
   , toOptionalTest
   , toListTest
   , withFocusTest
+  , setFocusTest
   ]
 
 functorTest :: TestTree
@@ -72,4 +74,13 @@ withFocusTest =
       withFocus (+1) (zipper [] 0 [1]) @?= zipper [] 1 [1]
   , testCase "left and right" $
       withFocus (+1) (zipper [1,0] 2 [3,4]) @?= zipper [1,0] 3 [3,4]
+  ]
+
+setFocusTest :: TestTree
+setFocusTest =
+  testGroup "setFocus" [
+    testCase "empty left" $
+      setFocus 1 (zipper [] 0 [1]) @?= zipper [] 1 [1]
+  , testCase "left and right" $
+      setFocus 1 (zipper [1,0] 2 [3,4]) @?= zipper [1,0] 1 [3,4]
   ]

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -15,8 +15,9 @@ import           Course.Functor        ((<$>))
 import           Course.List           (List (..), isEmpty)
 import           Course.ListZipper     (MaybeListZipper (..), findLeft,
                                         findRight, fromList, hasLeft, hasRight,
-                                        setFocus, toList, toListZ, toOptional,
-                                        withFocus, zipper, (-<<))
+                                        moveLeftLoop, moveRightLoop, setFocus,
+                                        toList, toListZ, toOptional, withFocus,
+                                        zipper, (-<<))
 import           Course.Optional       (Optional (Empty))
 
 import           Course.Gens           (forAllLists, genIntegerList)
@@ -35,6 +36,8 @@ test_ListZipper =
   , hasRightTest
   , findLeftTest
   , findRightTest
+  , moveLeftLoopTest
+  , moveRightLoopTest
   ]
 
 functorTest :: TestTree
@@ -134,6 +137,24 @@ findRightTest =
       findRight (== 1) (zipper [2,3] 1 [4,5,1]) @?= IsZ (zipper [5,4,1,2,3] 1 [])
   , testCase "multiple matches in right" $
       findRight (== 1) (zipper [2,3] 1 [1,4,5,1]) @?= IsZ (zipper [1,2,3] 1 [4,5,1])
+  ]
+
+moveLeftLoopTest :: TestTree
+moveLeftLoopTest =
+  testGroup "moveLeftLoop" [
+    testCase "with left" $
+      moveLeftLoop (zipper [3,2,1] 4 [5,6,7]) @?= zipper [2,1] 3 [4,5,6,7]
+  , testCase "empty left" $
+      moveLeftLoop (zipper [] 1 [2,3,4]) @?= zipper [3,2,1] 4 []
+  ]
+
+moveRightLoopTest :: TestTree
+moveRightLoopTest =
+  testGroup "moveRightLoop" [
+    testCase "with right" $
+      moveRightLoop (zipper [3,2,1] 4 [5,6,7]) @?= zipper [4,3,2,1] 5 [6,7]
+  , testCase "empty right" $
+      moveRightLoop (zipper [3,2,1] 4 []) @?= zipper [] 1 [2,3,4]
   ]
 
 genListAndBool :: Gen (List Integer, Bool)

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -27,9 +27,9 @@ test_ListZipper =
   testGroup "ListZipper" [
     functorTest
   , functorMaybeTest
+  , toListTest
   , fromListTest
   , toOptionalTest
-  , toListTest
   , withFocusTest
   , setFocusTest
   , hasLeftTest
@@ -56,6 +56,17 @@ functorMaybeTest =
   testCase "MaybeListZipper (<$>)" $
     (+1) <$> (IsZ (zipper [3,2,1] 4 [5,6,7])) @?= IsZ (zipper [4,3,2] 5 [6,7,8])
 
+toListTest :: TestTree
+toListTest =
+  testGroup "toList" [
+    testCase "Optional empty list" $
+      toList <$> Empty @?= (Empty :: Optional (List Int))
+  , testCase "empty left" $
+      toList (zipper [] 1 [2,3,4]) @?= (1:.2:.3:.4:.Nil)
+  , testCase "lefts and rights" $
+      toList (zipper [3,2,1] 4 [5,6,7]) @?= (1:.2:.3:.4:.5:.6:.7:.Nil)
+  ]
+
 fromListTest :: TestTree
 fromListTest =
   testGroup "fromList" [
@@ -70,17 +81,6 @@ toOptionalTest =
   testGroup "toOptional" [
     testProperty "empty" $
       forAllLists (\xs -> isEmpty xs == (toOptional (fromList xs) == Empty))
-  ]
-
-toListTest :: TestTree
-toListTest =
-  testGroup "toList" [
-    testCase "Optional empty list" $
-      toList <$> toOptional (fromList Nil) @?= (Empty :: Optional (List Int))
-  , testCase "empty left" $
-      toList (zipper [] 1 [2,3,4]) @?= (1:.2:.3:.4:.Nil)
-  , testCase "lefts and rights" $
-      toList (zipper [3,2,1] 4 [5,6,7]) @?= (1:.2:.3:.4:.5:.6:.7:.Nil)
   ]
 
 withFocusTest :: TestTree

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -11,12 +11,13 @@ import           Test.Tasty.QuickCheck (testProperty)
 import           Course.Core
 import           Course.Functor        ((<$>))
 import           Course.List           (List (..), isEmpty)
-import           Course.ListZipper     (ListZipper, MaybeListZipper (..), dropLefts,
-                                        findLeft, findRight, fromList, hasLeft,
-                                        hasRight, moveLeft, moveLeftLoop,
-                                        moveRight, moveRightLoop, setFocus,
-                                        swapLeft, swapRight, toList, toListZ,
-                                        toOptional, withFocus, zipper, (-<<))
+import           Course.ListZipper     (ListZipper, MaybeListZipper (..),
+                                        dropLefts, dropRights, findLeft,
+                                        findRight, fromList, hasLeft, hasRight,
+                                        moveLeft, moveLeftLoop, moveRight,
+                                        moveRightLoop, setFocus, swapLeft,
+                                        swapRight, toList, toListZ, toOptional,
+                                        withFocus, zipper, (-<<))
 import           Course.Optional       (Optional (Empty))
 
 import           Course.Gens           (forAllLists, forAllListsAndBool)
@@ -41,6 +42,8 @@ test_ListZipper =
   , moveRightTest
   , swapLeftTest
   , swapRightTest
+  , dropLeftsTest
+  , dropRightsTest
   ]
 
 functorTest :: TestTree
@@ -203,6 +206,17 @@ dropLeftsTest =
       dropLefts (zipper [3,2,1] 4 [5,6,7]) @?= zipper [] 4 [5,6,7]
   , testCase "empty left" $
       dropLefts (zipper [] 1 [2,3,4]) @?= zipper [] 1 [2,3,4]
-  , testProperty "dropLefts empties left of zipper" $
-      (\(l,x,r) -> dropLefts (zipper l x r) == (zipper [] x r :: ListZipper Integer))
+  , testProperty "dropLefts empties left of zipper"
+      (\l x r -> dropLefts (zipper l x r) == (zipper [] x r :: ListZipper Integer))
+  ]
+
+dropRightsTest :: TestTree
+dropRightsTest =
+  testGroup "dropRights" [
+    testCase "with right" $
+      dropRights (zipper [3,2,1] 4 [5,6,7]) @?= zipper [3,2,1] 4 []
+  , testCase "empty right" $
+      dropRights (zipper [3,2,1] 4 []) @?= zipper [3,2,1] 4 []
+  , testProperty "dropRights empties right of zipper"
+      (\l x r -> dropRights (zipper l x r) == (zipper l x [] :: ListZipper Integer))
   ]

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -1,0 +1,37 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Course.ListZipperTest where
+
+
+import           Test.Tasty        (TestTree, testGroup)
+import           Test.Tasty.HUnit  (testCase, (@?=))
+
+import           Course.Core
+import           Course.Functor    ((<$>))
+import           Course.List       (List (..))
+import           Course.ListZipper (MaybeListZipper (..), fromList, zipper)
+
+test_ListZipper :: TestTree
+test_ListZipper =
+  testGroup "ListZipper" [
+    functorTest
+  , functorMaybeTest
+  , fromListTest
+  ]
+
+functorTest :: TestTree
+functorTest =
+  testCase "ListZipper (<$>)" $
+    (+1) <$> (zipper [3,2,1] 4 [5,6,7]) @?= zipper [4,3,2] 5 [6,7,8]
+
+functorMaybeTest :: TestTree
+functorMaybeTest =
+  testCase "MaybeListZipper (<$>)" $
+    (+1) <$> (IsZ (zipper [3,2,1] 4 [5,6,7])) @?= IsZ (zipper [4,3,2] 5 [6,7,8])
+
+fromListTest :: TestTree
+fromListTest =
+  testGroup "fromList" [
+    testCase "non-empty" $ fromList (1 :. 2 :. 3 :. Nil) @?= IsZ (zipper [] 1 [2,3])
+  ]

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -12,7 +12,7 @@ import           Course.Core
 import           Course.Functor        ((<$>))
 import           Course.List           (List (..), isEmpty)
 import           Course.ListZipper     (MaybeListZipper (..), fromList, toListZ,
-                                        toOptional, zipper)
+                                        toOptional, zipper, toList)
 import           Course.Optional       (Optional (Empty))
 
 import           Course.ListTest       (forAllLists)
@@ -24,6 +24,7 @@ test_ListZipper =
   , functorMaybeTest
   , fromListTest
   , toOptionalTest
+  , toListTest
   ]
 
 functorTest :: TestTree
@@ -50,4 +51,15 @@ toOptionalTest =
   testGroup "toOptional" [
     testProperty "empty" $
       forAllLists (\xs -> isEmpty xs == (toOptional (fromList xs) == Empty))
+  ]
+
+toListTest :: TestTree
+toListTest =
+  testGroup "toList" [
+    testCase "Optional empty list" $
+      toList <$> toOptional (fromList Nil) @?= (Empty :: Optional (List Int))
+  , testCase "empty lefts" $
+      toList (zipper [] 1 [2,3,4]) @?= (1:.2:.3:.4:.Nil)
+  , testCase "lefts and rights" $
+      toList (zipper [3,2,1] 4 [5,6,7]) @?= (1:.2:.3:.4:.5:.6:.7:.Nil)
   ]

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -11,8 +11,8 @@ import           Test.Tasty.QuickCheck (testProperty)
 import           Course.Core
 import           Course.Functor        ((<$>))
 import           Course.List           (List (..), isEmpty)
-import           Course.ListZipper     (MaybeListZipper (..), fromList, toListZ,
-                                        toOptional, zipper, toList)
+import           Course.ListZipper     (MaybeListZipper (..), fromList, toList,
+                                        toListZ, toOptional, withFocus, zipper)
 import           Course.Optional       (Optional (Empty))
 
 import           Course.ListTest       (forAllLists)
@@ -25,6 +25,7 @@ test_ListZipper =
   , fromListTest
   , toOptionalTest
   , toListTest
+  , withFocusTest
   ]
 
 functorTest :: TestTree
@@ -58,8 +59,17 @@ toListTest =
   testGroup "toList" [
     testCase "Optional empty list" $
       toList <$> toOptional (fromList Nil) @?= (Empty :: Optional (List Int))
-  , testCase "empty lefts" $
+  , testCase "empty left" $
       toList (zipper [] 1 [2,3,4]) @?= (1:.2:.3:.4:.Nil)
   , testCase "lefts and rights" $
       toList (zipper [3,2,1] 4 [5,6,7]) @?= (1:.2:.3:.4:.5:.6:.7:.Nil)
+  ]
+
+withFocusTest :: TestTree
+withFocusTest =
+  testGroup "withFocus" [
+    testCase "empty left" $
+      withFocus (+1) (zipper [] 0 [1]) @?= zipper [] 1 [1]
+  , testCase "left and right" $
+      withFocus (+1) (zipper [1,0] 2 [3,4]) @?= zipper [1,0] 3 [3,4]
   ]

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -16,9 +16,9 @@ import           Course.List           (List (..), isEmpty)
 import           Course.ListZipper     (MaybeListZipper (..), findLeft,
                                         findRight, fromList, hasLeft, hasRight,
                                         moveLeft, moveLeftLoop, moveRight,
-                                        moveRightLoop, setFocus, toList,
-                                        toListZ, toOptional, withFocus, zipper,
-                                        (-<<))
+                                        moveRightLoop, setFocus, swapLeft,
+                                        swapRight, toList, toListZ, toOptional,
+                                        withFocus, zipper, (-<<))
 import           Course.Optional       (Optional (Empty))
 
 import           Course.Gens           (forAllLists, genIntegerList)
@@ -41,6 +41,8 @@ test_ListZipper =
   , moveRightLoopTest
   , moveLeftTest
   , moveRightTest
+  , swapLeftTest
+  , swapRightTest
   ]
 
 functorTest :: TestTree
@@ -176,6 +178,24 @@ moveRightTest =
       moveRight (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [4,3,2,1] 5 [6,7])
   , testCase "empty right" $
       moveRight (zipper [3,2,1] 4 []) @?= IsNotZ
+  ]
+
+swapLeftTest :: TestTree
+swapLeftTest =
+  testGroup "swapLeft" [
+    testCase "with left" $
+      swapLeft (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [4,2,1] 3 [5,6,7])
+  , testCase "empty left" $
+      swapLeft (zipper [] 1 [2,3,4]) @?= IsNotZ
+  ]
+
+swapRightTest :: TestTree
+swapRightTest =
+  testGroup "swapRight" [
+    testCase "with right" $
+      swapRight (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [3,2,1] 5 [4,6,7])
+  , testCase "empty right" $
+      swapRight (zipper [3,2,1] 4 []) @?= IsNotZ
   ]
 
 genListAndBool :: Gen (List Integer, Bool)

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -23,6 +23,7 @@ test_ListZipper =
     functorTest
   , functorMaybeTest
   , fromListTest
+  , toOptionalTest
   ]
 
 functorTest :: TestTree

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -15,9 +15,10 @@ import           Course.Functor        ((<$>))
 import           Course.List           (List (..), isEmpty)
 import           Course.ListZipper     (MaybeListZipper (..), findLeft,
                                         findRight, fromList, hasLeft, hasRight,
-                                        moveLeftLoop, moveRightLoop, setFocus,
-                                        toList, toListZ, toOptional, withFocus,
-                                        zipper, (-<<))
+                                        moveLeft, moveLeftLoop, moveRight,
+                                        moveRightLoop, setFocus, toList,
+                                        toListZ, toOptional, withFocus, zipper,
+                                        (-<<))
 import           Course.Optional       (Optional (Empty))
 
 import           Course.Gens           (forAllLists, genIntegerList)
@@ -38,6 +39,8 @@ test_ListZipper =
   , findRightTest
   , moveLeftLoopTest
   , moveRightLoopTest
+  , moveLeftTest
+  , moveRightTest
   ]
 
 functorTest :: TestTree
@@ -155,6 +158,24 @@ moveRightLoopTest =
       moveRightLoop (zipper [3,2,1] 4 [5,6,7]) @?= zipper [4,3,2,1] 5 [6,7]
   , testCase "empty right" $
       moveRightLoop (zipper [3,2,1] 4 []) @?= zipper [] 1 [2,3,4]
+  ]
+
+moveLeftTest :: TestTree
+moveLeftTest =
+  testGroup "moveLeft" [
+    testCase "with left" $
+      moveLeft (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [2,1] 3 [4,5,6,7])
+  , testCase "empty left" $
+      moveLeft (zipper [] 1 [2,3,4]) @?= IsNotZ
+  ]
+
+moveRightTest :: TestTree
+moveRightTest =
+  testGroup "moveRight" [
+    testCase "with right" $
+      moveRight (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [4,3,2,1] 5 [6,7])
+  , testCase "empty right" $
+      moveRight (zipper [3,2,1] 4 []) @?= IsNotZ
   ]
 
 genListAndBool :: Gen (List Integer, Bool)

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -4,17 +4,18 @@
 module Course.ListZipperTest where
 
 
-import           Test.QuickCheck       (forAllShrink)
 import           Test.Tasty            (TestTree, testGroup)
 import           Test.Tasty.HUnit      (testCase, (@?=))
 import           Test.Tasty.QuickCheck (testProperty)
 
 import           Course.Core
 import           Course.Functor        ((<$>))
-import           Course.List           (List (..))
-import           Course.ListZipper     (MaybeListZipper (..), fromList, zipper, toListZ)
+import           Course.List           (List (..), isEmpty)
+import           Course.ListZipper     (MaybeListZipper (..), fromList, toListZ,
+                                        toOptional, zipper)
+import           Course.Optional       (Optional (Empty))
 
-import           Course.ListTest       (genIntegerList, shrinkList)
+import           Course.ListTest       (forAllLists)
 
 test_ListZipper :: TestTree
 test_ListZipper =
@@ -40,5 +41,12 @@ fromListTest =
     testCase "non-empty" $ fromList (1 :. 2 :. 3 :. Nil) @?= IsZ (zipper [] 1 [2,3])
   , testCase "empty" $ fromList Nil @?= (IsNotZ :: MaybeListZipper Integer)
   , testProperty "round trip" $
-      forAllShrink genIntegerList shrinkList (\xs -> toListZ (fromList xs) == xs)
+      forAllLists (\xs -> toListZ (fromList xs) == xs)
+  ]
+
+toOptionalTest :: TestTree
+toOptionalTest =
+  testGroup "toOptional" [
+    testProperty "empty" $
+      forAllLists (\xs -> isEmpty xs == (toOptional (fromList xs) == Empty))
   ]

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -14,9 +14,9 @@ import           Course.Core
 import           Course.Functor        ((<$>))
 import           Course.List           (List (..), isEmpty)
 import           Course.ListZipper     (MaybeListZipper (..), findLeft,
-                                        fromList, hasLeft, hasRight, setFocus,
-                                        toList, toListZ, toOptional, withFocus,
-                                        zipper, (-<<))
+                                        findRight, fromList, hasLeft, hasRight,
+                                        setFocus, toList, toListZ, toOptional,
+                                        withFocus, zipper, (-<<))
 import           Course.Optional       (Optional (Empty))
 
 import           Course.Gens           (forAllLists, genIntegerList)
@@ -34,6 +34,7 @@ test_ListZipper =
   , hasLeftTest
   , hasRightTest
   , findLeftTest
+  , findRightTest
   ]
 
 functorTest :: TestTree
@@ -118,6 +119,21 @@ findLeftTest =
       findLeft (== 1) (zipper [2,1] 1 [4,5]) @?= IsZ (zipper [] 1 [2,1,4,5])
   , testCase "multiple matches in left" $
       findLeft (== 1) (zipper [1,2,1] 3 [4,5]) @?= IsZ (zipper [2,1] 1 [3,4,5])
+  ]
+
+findRightTest :: TestTree
+findRightTest =
+  testGroup "findRight" [
+    testProperty "missing element returns IsNotZ" $
+      forAllLists (\xs -> findRight (const False) -<< fromList xs == IsNotZ)
+  , testCase "found in right" $
+      findRight (== 5) (zipper [2,1] 3 [4,5]) @?= IsZ (zipper [4,3,2,1] 5 [])
+  , testCase "not found" $
+      findRight (== 6) (zipper [2,1] 3 [4,5]) @?= IsNotZ
+  , testCase "one match in right" $
+      findRight (== 1) (zipper [2,3] 1 [4,5,1]) @?= IsZ (zipper [5,4,1,2,3] 1 [])
+  , testCase "multiple matches in right" $
+      findRight (== 1) (zipper [2,3] 1 [1,4,5,1]) @?= IsZ (zipper [1,2,3] 1 [4,5,1])
   ]
 
 genListAndBool :: Gen (List Integer, Bool)

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -4,13 +4,17 @@
 module Course.ListZipperTest where
 
 
-import           Test.Tasty        (TestTree, testGroup)
-import           Test.Tasty.HUnit  (testCase, (@?=))
+import           Test.QuickCheck       (forAllShrink)
+import           Test.Tasty            (TestTree, testGroup)
+import           Test.Tasty.HUnit      (testCase, (@?=))
+import           Test.Tasty.QuickCheck (testProperty)
 
 import           Course.Core
-import           Course.Functor    ((<$>))
-import           Course.List       (List (..))
-import           Course.ListZipper (MaybeListZipper (..), fromList, zipper)
+import           Course.Functor        ((<$>))
+import           Course.List           (List (..))
+import           Course.ListZipper     (MaybeListZipper (..), fromList, zipper, toListZ)
+
+import           Course.ListTest       (genIntegerList, shrinkList)
 
 test_ListZipper :: TestTree
 test_ListZipper =
@@ -34,4 +38,7 @@ fromListTest :: TestTree
 fromListTest =
   testGroup "fromList" [
     testCase "non-empty" $ fromList (1 :. 2 :. 3 :. Nil) @?= IsZ (zipper [] 1 [2,3])
+  , testCase "empty" $ fromList Nil @?= (IsNotZ :: MaybeListZipper Integer)
+  , testProperty "round trip" $
+      forAllShrink genIntegerList shrinkList (\xs -> toListZ (fromList xs) == xs)
   ]

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -16,9 +16,9 @@ import           Course.ListZipper     (ListZipper, MaybeListZipper (..),
                                         findRight, fromList, hasLeft, hasRight,
                                         moveLeft, moveLeftLoop, moveLeftN,
                                         moveLeftN', moveRight, moveRightLoop,
-                                        moveRightN, setFocus, swapLeft,
-                                        swapRight, toList, toListZ, toOptional,
-                                        withFocus, zipper, (-<<))
+                                        moveRightN, moveRightN', setFocus,
+                                        swapLeft, swapRight, toList, toListZ,
+                                        toOptional, withFocus, zipper, (-<<))
 import           Course.Optional       (Optional (Empty))
 
 import           Course.Gens           (forAllLists, forAllListsAndBool)
@@ -48,6 +48,21 @@ test_ListZipper =
   , moveLeftNTest
   , moveRightNTest
   , moveLeftN'Test
+  , moveRightN'Test
+  , nthTest
+  , indexTest
+  , endTest
+  , startTest
+  , deletePullLeftTest
+  , deletePullRightTest
+  , insertPushLeftTest
+  , insertPushRightTest
+  , applicativeTest
+  , applicativeMaybeTest
+  , extendTest
+  , extendMaybeTest
+  , traversableTest
+  , traversableMaybeTest
   ]
 
 functorTest :: TestTree
@@ -263,3 +278,60 @@ moveLeftN'Test =
   , testCase "negative - out of bounds on right only" $
       moveLeftN' (-4) (zipper [5,4,3,2,1] 6 [7,8,9]) @?= Left 3
   ]
+
+moveRightN'Test :: TestTree
+moveRightN'Test =
+  testGroup "moveRightN'" [
+    testCase "positive - out of bounds both sides" $
+      moveRightN' 4 (zipper [3,2,1] 4 [5,6,7]) @?= Left 3
+  , testCase "positive in range" $
+      moveRightN' 1 (zipper [3,2,1] 4 [5,6,7]) @?= Right (zipper [4,3,2,1] 5 [6,7])
+  , testProperty "moving zero is `Right . id`" $
+      (\l x r -> let lz = (zipper l x r :: ListZipper Integer) in moveRightN' 0 lz == (Right . id $ lz))
+  , testCase "negative in range" $
+      moveRightN' (-2) (zipper [3,2,1] 4 [5,6,7]) @?= Right (zipper [1] 2 [3,4,5,6,7])
+  , testCase "negative - out of bounds both sides" $
+      moveRightN' (-4) (zipper [3,2,1] 4 [5,6,7]) @?= Left 3
+  ]
+
+nthTest :: TestTree
+nthTest = error "todo"
+
+indexTest :: TestTree
+indexTest = error "todo"
+
+endTest :: TestTree
+endTest = error "todo"
+
+startTest :: TestTree
+startTest = error "todo"
+
+deletePullLeftTest :: TestTree
+deletePullLeftTest = error "todo"
+
+deletePullRightTest :: TestTree
+deletePullRightTest = error "todo"
+
+insertPushLeftTest :: TestTree
+insertPushLeftTest = error "todo"
+
+insertPushRightTest :: TestTree
+insertPushRightTest = error "todo"
+
+applicativeTest :: TestTree
+applicativeTest = error "todo"
+
+applicativeMaybeTest :: TestTree
+applicativeMaybeTest = error "todo"
+
+extendTest :: TestTree
+extendTest = error "todo"
+
+extendMaybeTest :: TestTree
+extendMaybeTest = error "todo"
+
+traversableTest :: TestTree
+traversableTest = error "todo"
+
+traversableMaybeTest :: TestTree
+traversableMaybeTest = error "todo"

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -9,9 +9,10 @@ import           Test.Tasty            (TestTree, testGroup)
 import           Test.Tasty.HUnit      (testCase, (@?=))
 import           Test.Tasty.QuickCheck (testProperty)
 
+import           Course.Applicative    (pure, (<*>))
 import           Course.Core
 import           Course.Functor        ((<$>))
-import           Course.List           (List (..), isEmpty)
+import           Course.List           (List (..), all, isEmpty, take)
 import           Course.ListZipper     (ListZipper, MaybeListZipper (..),
                                         deletePullLeft, deletePullRight,
                                         dropLefts, dropRights, end, findLeft,
@@ -374,7 +375,15 @@ insertPushRightTest =
   ]
 
 applicativeTest :: TestTree
-applicativeTest = error "todo"
+applicativeTest =
+  testGroup "Applicative" [
+    testProperty "pure produces infinite lefts" $
+      (\a n -> (all . (==) <*> take (n :: Int) . lefts . pure) (a :: Integer))
+  , testProperty "pure produces infinite rights" $
+      (\a n -> (all . (==) <*> take (n :: Int) . rights . pure) (a :: Integer))
+  , testCase "<*> applies functions to corresponding elements in zipper" $
+      zipper [(+2), (+10)] (*2) [(*3), (4*), (5+)] <*> zipper [3,2,1] 4 [5,6,7] @?= zipper [5,12] 8 [15,24,12]
+  ]
 
 applicativeMaybeTest :: TestTree
 applicativeMaybeTest = error "todo"

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -61,6 +61,7 @@ test_ListZipper =
   , applicativeMaybeTest
   , extendTest
   , extendMaybeTest
+  , comonadTest
   , traversableTest
   , traversableMaybeTest
   ]
@@ -329,6 +330,9 @@ extendTest = error "todo"
 
 extendMaybeTest :: TestTree
 extendMaybeTest = error "todo"
+
+comonadTest :: TestTree
+comonadTest = error "todo"
 
 traversableTest :: TestTree
 traversableTest = error "todo"

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -81,12 +81,12 @@ test_ListZipper =
 functorTest :: TestTree
 functorTest =
   testCase "ListZipper (<$>)" $
-    (+1) <$> (zipper [3,2,1] 4 [5,6,7]) @?= zipper [4,3,2] 5 [6,7,8]
+    (+1) <$> zipper [3,2,1] 4 [5,6,7] @?= zipper [4,3,2] 5 [6,7,8]
 
 functorMaybeTest :: TestTree
 functorMaybeTest =
   testCase "MaybeListZipper (<$>)" $
-    (+1) <$> (IsZ (zipper [3,2,1] 4 [5,6,7])) @?= IsZ (zipper [4,3,2] 5 [6,7,8])
+    (+1) <$> IsZ (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [4,3,2] 5 [6,7,8])
 
 toListTest :: TestTree
 toListTest =
@@ -280,8 +280,9 @@ moveLeftN'Test =
       moveLeftN' 4 (zipper [3,2,1] 4 [5,6,7]) @?= Left 3
   , testCase "positive in range" $
       moveLeftN' 1 (zipper [3,2,1] 4 [5,6,7]) @?= Right (zipper [2,1] 3 [4,5,6,7])
-  , testProperty "moving zero is `Right . id`" $
-      (\l x r -> let lz = (zipper l x r :: ListZipper Integer) in moveLeftN' 0 lz == (Right . id $ lz))
+  , testProperty "moving zero is `Right . id`"
+      (\l x r -> let lz = zipper l x r :: ListZipper Integer
+                  in moveLeftN' 0 lz == (Right . id $ lz))
   , testCase "negative in range" $
       moveLeftN' (-2) (zipper [3,2,1] 4 [5,6,7]) @?= Right (zipper [5,4,3,2,1] 6 [7])
   , testCase "negative out of bounds" $
@@ -299,7 +300,7 @@ moveRightN'Test =
       moveRightN' 4 (zipper [3,2,1] 4 [5,6,7]) @?= Left 3
   , testCase "positive in range" $
       moveRightN' 1 (zipper [3,2,1] 4 [5,6,7]) @?= Right (zipper [4,3,2,1] 5 [6,7])
-  , testProperty "moving zero is `Right . id`" $
+  , testProperty "moving zero is `Right . id`"
       (\l x r -> let lz = (zipper l x r :: ListZipper Integer) in moveRightN' 0 lz == (Right . id $ lz))
   , testCase "negative in range" $
       moveRightN' (-2) (zipper [3,2,1] 4 [5,6,7]) @?= Right (zipper [1] 2 [3,4,5,6,7])
@@ -382,9 +383,9 @@ insertPushRightTest =
 applicativeTest :: TestTree
 applicativeTest =
   testGroup "Applicative" [
-    testProperty "pure produces infinite lefts" $
+    testProperty "pure produces infinite lefts"
       (\a n -> (all . (==) <*> take (n :: Int) . lefts . pure) (a :: Integer))
-  , testProperty "pure produces infinite rights" $
+  , testProperty "pure produces infinite rights"
       (\a n -> (all . (==) <*> take (n :: Int) . rights . pure) (a :: Integer))
   , testCase "<*> applies functions to corresponding elements in zipper" $
       zipper [(+2), (+10)] (*2) [(*3), (4*), (5+)] <*> zipper [3,2,1] 4 [5,6,7] @?= zipper [5,12] 8 [15,24,12]
@@ -397,9 +398,9 @@ applicativeMaybeTest =
       notZ       = IsNotZ :: MaybeListZipper Integer
   in
     testGroup "Applicative (MaybeListZipper)" [
-      testProperty "pure produces infinite lefts" $
+      testProperty "pure produces infinite lefts"
         (\a n -> (all . (==) <*> take (n :: Int) . lefts . is . pure) (a :: Integer))
-    , testProperty "pure produces infinite rights" $
+    , testProperty "pure produces infinite rights"
         (\a n -> (all . (==) <*> take (n :: Int) . rights . is . pure) (a :: Integer))
     , testCase "IsZ <*> IsZ" $
         let z = IsZ (zipper [(+2), (+10)] (*2) [(*3), (4*), (5+)]) <*> IsZ (zipper [3,2,1] 4 [5,6,7])
@@ -407,8 +408,8 @@ applicativeMaybeTest =
     , testProperty "IsNotZ <*> IsZ" $
         let fs = (IsNotZ :: MaybeListZipper (Integer -> Integer))
          in forAllListZipper (\z -> (fs <*> IsZ z) == IsNotZ)
-    , testProperty "IsZ <*> IsNotZ" $
-         (\(Fun _ f) -> (IsZ (pure f) <*> notZ) == notZ)
+    , testProperty "IsZ <*> IsNotZ"
+        (\(Fun _ f) -> (IsZ (pure f) <*> notZ) == notZ)
     , testCase "IsNotZ <*> IsNotZ" $
         IsNotZ <*> notZ @?= notZ
     ]

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -81,12 +81,12 @@ test_ListZipper =
 functorTest :: TestTree
 functorTest =
   testCase "ListZipper (<$>)" $
-    (+1) <$> defaultZipper @?= zipper [4,3,2] 5 [6,7,8]
+    (+1) <$> (zipper [3,2,1] 4 [5,6,7]) @?= zipper [4,3,2] 5 [6,7,8]
 
 functorMaybeTest :: TestTree
 functorMaybeTest =
   testCase "MaybeListZipper (<$>)" $
-    (+1) <$> (IsZ defaultZipper) @?= IsZ (zipper [4,3,2] 5 [6,7,8])
+    (+1) <$> (IsZ (zipper [3,2,1] 4 [5,6,7])) @?= IsZ (zipper [4,3,2] 5 [6,7,8])
 
 toListTest :: TestTree
 toListTest =
@@ -96,7 +96,7 @@ toListTest =
   , testCase "empty left" $
       toList (zipper [] 1 [2,3,4]) @?= (1:.2:.3:.4:.Nil)
   , testCase "lefts and rights" $
-      toList defaultZipper @?= (1:.2:.3:.4:.5:.6:.7:.Nil)
+      toList (zipper [3,2,1] 4 [5,6,7]) @?= (1:.2:.3:.4:.5:.6:.7:.Nil)
   ]
 
 fromListTest :: TestTree
@@ -183,7 +183,7 @@ moveLeftLoopTest :: TestTree
 moveLeftLoopTest =
   testGroup "moveLeftLoop" [
     testCase "with left" $
-      moveLeftLoop defaultZipper @?= zipper [2,1] 3 [4,5,6,7]
+      moveLeftLoop (zipper [3,2,1] 4 [5,6,7]) @?= zipper [2,1] 3 [4,5,6,7]
   , testCase "empty left" $
       moveLeftLoop (zipper [] 1 [2,3,4]) @?= zipper [3,2,1] 4 []
   ]
@@ -192,7 +192,7 @@ moveRightLoopTest :: TestTree
 moveRightLoopTest =
   testGroup "moveRightLoop" [
     testCase "with right" $
-      moveRightLoop defaultZipper @?= zipper [4,3,2,1] 5 [6,7]
+      moveRightLoop (zipper [3,2,1] 4 [5,6,7]) @?= zipper [4,3,2,1] 5 [6,7]
   , testCase "empty right" $
       moveRightLoop (zipper [3,2,1] 4 []) @?= zipper [] 1 [2,3,4]
   ]
@@ -201,7 +201,7 @@ moveLeftTest :: TestTree
 moveLeftTest =
   testGroup "moveLeft" [
     testCase "with left" $
-      moveLeft defaultZipper @?= IsZ (zipper [2,1] 3 [4,5,6,7])
+      moveLeft (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [2,1] 3 [4,5,6,7])
   , testCase "empty left" $
       moveLeft (zipper [] 1 [2,3,4]) @?= IsNotZ
   ]
@@ -210,7 +210,7 @@ moveRightTest :: TestTree
 moveRightTest =
   testGroup "moveRight" [
     testCase "with right" $
-      moveRight defaultZipper @?= IsZ (zipper [4,3,2,1] 5 [6,7])
+      moveRight (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [4,3,2,1] 5 [6,7])
   , testCase "empty right" $
       moveRight (zipper [3,2,1] 4 []) @?= IsNotZ
   ]
@@ -219,7 +219,7 @@ swapLeftTest :: TestTree
 swapLeftTest =
   testGroup "swapLeft" [
     testCase "with left" $
-      swapLeft defaultZipper @?= IsZ (zipper [4,2,1] 3 [5,6,7])
+      swapLeft (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [4,2,1] 3 [5,6,7])
   , testCase "empty left" $
       swapLeft (zipper [] 1 [2,3,4]) @?= IsNotZ
   ]
@@ -228,7 +228,7 @@ swapRightTest :: TestTree
 swapRightTest =
   testGroup "swapRight" [
     testCase "with right" $
-      swapRight defaultZipper @?= IsZ (zipper [3,2,1] 5 [4,6,7])
+      swapRight (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [3,2,1] 5 [4,6,7])
   , testCase "empty right" $
       swapRight (zipper [3,2,1] 4 []) @?= IsNotZ
   ]
@@ -237,7 +237,7 @@ dropLeftsTest :: TestTree
 dropLeftsTest =
   testGroup "dropLeft" [
     testCase "with left" $
-      dropLefts defaultZipper @?= zipper [] 4 [5,6,7]
+      dropLefts (zipper [3,2,1] 4 [5,6,7]) @?= zipper [] 4 [5,6,7]
   , testCase "empty left" $
       dropLefts (zipper [] 1 [2,3,4]) @?= zipper [] 1 [2,3,4]
   , testProperty "dropLefts empties left of zipper"
@@ -248,7 +248,7 @@ dropRightsTest :: TestTree
 dropRightsTest =
   testGroup "dropRights" [
     testCase "with right" $
-      dropRights defaultZipper @?= zipper [3,2,1] 4 []
+      dropRights (zipper [3,2,1] 4 [5,6,7]) @?= zipper [3,2,1] 4 []
   , testCase "empty right" $
       dropRights (zipper [3,2,1] 4 []) @?= zipper [3,2,1] 4 []
   , testProperty "dropRights empties right of zipper"
@@ -277,15 +277,15 @@ moveLeftN'Test :: TestTree
 moveLeftN'Test =
   testGroup "moveLeftN'" [
     testCase "positive - out of bounds both sides" $
-      moveLeftN' 4 defaultZipper @?= Left 3
+      moveLeftN' 4 (zipper [3,2,1] 4 [5,6,7]) @?= Left 3
   , testCase "positive in range" $
-      moveLeftN' 1 defaultZipper @?= Right (zipper [2,1] 3 [4,5,6,7])
+      moveLeftN' 1 (zipper [3,2,1] 4 [5,6,7]) @?= Right (zipper [2,1] 3 [4,5,6,7])
   , testProperty "moving zero is `Right . id`" $
       (\l x r -> let lz = (zipper l x r :: ListZipper Integer) in moveLeftN' 0 lz == (Right . id $ lz))
   , testCase "negative in range" $
-      moveLeftN' (-2) defaultZipper @?= Right (zipper [5,4,3,2,1] 6 [7])
+      moveLeftN' (-2) (zipper [3,2,1] 4 [5,6,7]) @?= Right (zipper [5,4,3,2,1] 6 [7])
   , testCase "negative out of bounds" $
-      moveLeftN' (-4 ) defaultZipper @?= Left 3
+      moveLeftN' (-4 ) (zipper [3,2,1] 4 [5,6,7]) @?= Left 3
   , testCase "positive - out of bounds on left only" $
       moveLeftN' 4 (zipper [3,2,1] 4 [5,6,7,8,9]) @?= Left 3
   , testCase "negative - out of bounds on right only" $
@@ -296,29 +296,29 @@ moveRightN'Test :: TestTree
 moveRightN'Test =
   testGroup "moveRightN'" [
     testCase "positive - out of bounds both sides" $
-      moveRightN' 4 defaultZipper @?= Left 3
+      moveRightN' 4 (zipper [3,2,1] 4 [5,6,7]) @?= Left 3
   , testCase "positive in range" $
-      moveRightN' 1 defaultZipper @?= Right (zipper [4,3,2,1] 5 [6,7])
+      moveRightN' 1 (zipper [3,2,1] 4 [5,6,7]) @?= Right (zipper [4,3,2,1] 5 [6,7])
   , testProperty "moving zero is `Right . id`" $
       (\l x r -> let lz = (zipper l x r :: ListZipper Integer) in moveRightN' 0 lz == (Right . id $ lz))
   , testCase "negative in range" $
-      moveRightN' (-2) defaultZipper @?= Right (zipper [1] 2 [3,4,5,6,7])
+      moveRightN' (-2) (zipper [3,2,1] 4 [5,6,7]) @?= Right (zipper [1] 2 [3,4,5,6,7])
   , testCase "negative - out of bounds both sides" $
-      moveRightN' (-4) defaultZipper @?= Left 3
+      moveRightN' (-4) (zipper [3,2,1] 4 [5,6,7]) @?= Left 3
   ]
 
 nthTest :: TestTree
 nthTest =
   testGroup "nth" [
-    testCase "have 1"    $ nth 1 defaultZipper @?= IsZ (zipper [1] 2 [3,4,5,6,7])
-  , testCase "have 5"    $ nth 5 defaultZipper @?= IsZ (zipper [5,4,3,2,1] 6 [7])
-  , testCase "missing 8" $ nth 8 defaultZipper @?= IsNotZ
+    testCase "have 1"    $ nth 1 (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [1] 2 [3,4,5,6,7])
+  , testCase "have 5"    $ nth 5 (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [5,4,3,2,1] 6 [7])
+  , testCase "missing 8" $ nth 8 (zipper [3,2,1] 4 [5,6,7]) @?= IsNotZ
   ]
 
 indexTest :: TestTree
 indexTest =
   testGroup "index" [
-    testCase "index works" $ index defaultZipper @?= 3
+    testCase "index works" $ index (zipper [3,2,1] 4 [5,6,7]) @?= 3
   , testProperty "Always returns the index on a valid zipper" $
       forAllListZipperWithInt (\(z,i) -> optional True (\z' -> index z' == i) (toOptional (nth i z)))
   ]
@@ -326,7 +326,7 @@ indexTest =
 endTest :: TestTree
 endTest =
   testGroup "end" [
-    testCase "end" $ end defaultZipper @?= zipper [6,5,4,3,2,1] 7 []
+    testCase "end" $ end (zipper [3,2,1] 4 [5,6,7]) @?= zipper [6,5,4,3,2,1] 7 []
   , testProperty "end never changes the zipper's contents" $
       forAllListZipper (\z -> toList z == toList (end z))
   , testProperty "never have rights after calling end" $
@@ -336,7 +336,7 @@ endTest =
 startTest :: TestTree
 startTest =
   testGroup "start" [
-    testCase "start" $ start defaultZipper @?= zipper [] 1 [2,3,4,5,6,7]
+    testCase "start" $ start (zipper [3,2,1] 4 [5,6,7]) @?= zipper [] 1 [2,3,4,5,6,7]
   , testProperty "start never changes the zipper's contents" $
       forAllListZipper (\z -> toList z == toList (start z))
   , testProperty "never have lefts after calling start" $
@@ -346,14 +346,14 @@ startTest =
 deletePullLeftTest :: TestTree
 deletePullLeftTest =
   testGroup "deletePullLeft" [
-    testCase "non-empty lefts" $ deletePullLeft defaultZipper @?= IsZ (zipper [2,1] 3 [5,6,7])
+    testCase "non-empty lefts" $ deletePullLeft (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [2,1] 3 [5,6,7])
   , testCase "empty lefts" $ deletePullLeft (zipper [] 1 [2,3,4]) @?= IsNotZ
   ]
 
 deletePullRightTest :: TestTree
 deletePullRightTest =
   testGroup "deletePullRight" [
-    testCase "non-empty rights" $ deletePullRight defaultZipper @?= IsZ (zipper [3,2,1] 5 [6,7])
+    testCase "non-empty rights" $ deletePullRight (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [3,2,1] 5 [6,7])
   , testCase "empty rights" $ deletePullLeft (zipper [3,2,1] 4 []) @?= IsNotZ
   ]
 
@@ -361,22 +361,22 @@ insertPushLeftTest :: TestTree
 insertPushLeftTest =
   testGroup "insertPushLeft" [
     testCase "non-empty lefts" $
-      insertPushLeft 15 defaultZipper @?= zipper [4,3,2,1] 15 [5,6,7]
+      insertPushLeft 15 (zipper [3,2,1] 4 [5,6,7]) @?= zipper [4,3,2,1] 15 [5,6,7]
   , testCase "empty lefts" $
       insertPushLeft 15 (zipper [] 1 [2,3,4]) @?= zipper [1] 15 [2,3,4]
   , testProperty "deletePullLeft . insertPushLeft == id" $
-      forAllListZipperWithInt (\(z,i) -> optional False (==z) (toOptional (deletePullLeft (insertPushLeft (fromIntegral i) z))))
+      forAllListZipperWithInt (\(z,i) -> optional False (==z) (toOptional (deletePullLeft (insertPushLeft (P.fromIntegral i) z))))
   ]
 
 insertPushRightTest :: TestTree
 insertPushRightTest =
   testGroup "insertPushRight" [
     testCase "non-empty rights" $
-      insertPushRight 15 defaultZipper @?= zipper [3,2,1] 15 [4,5,6,7]
+      insertPushRight 15 (zipper [3,2,1] 4 [5,6,7]) @?= zipper [3,2,1] 15 [4,5,6,7]
   , testCase "empty rights" $
       insertPushRight 15 (zipper [3,2,1] 4 []) @?= zipper [3,2,1] 15 [4]
   , testProperty "deletePullRight . insertPushRight == id" $
-      forAllListZipperWithInt (\(z,i) -> optional False (==z) (toOptional (deletePullRight (insertPushRight (fromIntegral i) z))))
+      forAllListZipperWithInt (\(z,i) -> optional False (==z) (toOptional (deletePullRight (insertPushRight (P.fromIntegral i) z))))
   ]
 
 applicativeTest :: TestTree
@@ -450,9 +450,6 @@ traversableTest =
   ]
 
 traversableMaybeTest :: TestTree
-
-defaultZipper :: ListZipper Integer
-defaultZipper = zipper [3,2,1] 4 [5,6,7]
 traversableMaybeTest =
   testGroup "Traversable (MaybeListZipper)" [
     testCase "IsNotZ" $ traverse id IsNotZ @?= (Empty :: Optional (MaybeListZipper Integer))

--- a/test/Course/StateTTest.hs
+++ b/test/Course/StateTTest.hs
@@ -3,9 +3,8 @@
 
 module Course.StateTTest where
 
-import qualified Prelude               as P ((++), String)
+import qualified Prelude               as P (String, (++))
 
-import           Test.QuickCheck       (forAllShrink)
 import           Test.Tasty            (TestTree, testGroup)
 import           Test.Tasty.HUnit      (testCase, (@?=))
 import           Test.Tasty.QuickCheck (testProperty)
@@ -14,14 +13,15 @@ import           Course.Applicative    (pure, (<*>))
 import           Course.Core
 import           Course.ExactlyOne     (ExactlyOne (..))
 import           Course.Functor        ((<$>))
+import           Course.Gens           (forAllLists)
 import           Course.List           (List (..), flatMap, listh)
-import           Course.ListTest       (genIntegerList, shrinkList)
 import           Course.Monad          ((=<<), (>>=))
 import           Course.Optional       (Optional (..))
 import           Course.State          (put, runState)
-import           Course.StateT         (OptionalT (..), StateT (..), distinct',
-                                        distinctF, getT, putT, runOptionalT,
-                                        runState', state', log1, distinctG, Logger (..))
+import           Course.StateT         (Logger (..), OptionalT (..),
+                                        StateT (..), distinct', distinctF,
+                                        distinctG, getT, log1, putT,
+                                        runOptionalT, runState', state')
 
 test_StateT :: TestTree
 test_StateT =
@@ -99,8 +99,7 @@ putTTest =
 distinct'Test :: TestTree
 distinct'Test =
   testProperty "distinct'" $
-    forAllShrink genIntegerList shrinkList (\xs ->
-      distinct' xs == distinct' (flatMap (\x -> x :. x :. Nil) xs))
+    forAllLists (\xs -> distinct' xs == distinct' (flatMap (\x -> x :. x :. Nil) xs))
 
 distinctFTest :: TestTree
 distinctFTest =

--- a/test/Course/StateTest.hs
+++ b/test/Course/StateTest.hs
@@ -10,14 +10,14 @@ import qualified Prelude                  as P ((++))
 import           Test.QuickCheck.Function (Fun (..))
 import           Test.Tasty               (TestTree, testGroup)
 import           Test.Tasty.HUnit         (testCase, (@?=))
-import           Test.Tasty.QuickCheck    (forAllShrink, testProperty)
+import           Test.Tasty.QuickCheck    (testProperty)
 
 import           Course.Applicative       (pure, (<*>))
 import           Course.Core
 import           Course.Functor           ((<$>))
 import           Course.List              (List (..), filter, flatMap, hlist,
                                            length, listh, span, (++))
-import           Course.ListTest          (genIntegerList, shrinkList)
+import           Course.Gens          (forAllLists)
 import           Course.Monad
 import           Course.Optional          (Optional (..))
 import           Course.State             (State (..), distinct, eval, exec,
@@ -97,14 +97,14 @@ findMTest =
 firstRepeatTest :: TestTree
 firstRepeatTest =
   testGroup "firstRepeat" [
-    testProperty "finds repeats" $ forAllShrink genIntegerList shrinkList (\xs ->
+    testProperty "finds repeats" $ forAllLists (\xs ->
       case firstRepeat xs of
         Empty ->
           let xs' = hlist xs
            in nub xs' == xs'
         Full x -> length (filter (== x) xs) > 1
     )
-  , testProperty "" $ forAllShrink genIntegerList shrinkList (\xs ->
+  , testProperty "" $ forAllLists (\xs ->
       case firstRepeat xs of
         Empty -> True
         Full x ->
@@ -119,9 +119,9 @@ distinctTest :: TestTree
 distinctTest =
   testGroup "distinct" [
     testProperty "No repeats after distinct" $
-      forAllShrink genIntegerList shrinkList (\xs -> firstRepeat (distinct xs) == Empty)
+      forAllLists (\xs -> firstRepeat (distinct xs) == Empty)
   , testProperty "" $
-      forAllShrink genIntegerList shrinkList (\xs -> distinct xs == distinct (flatMap (\x -> x :. x :. Nil) xs))
+      forAllLists (\xs -> distinct xs == distinct (flatMap (\x -> x :. x :. Nil) xs))
   ]
 
 isHappyTest :: TestTree


### PR DESCRIPTION
Few changes beyond just adding the test module:

 - Move Gens from `ListTest` into their own module and add zipper Gens
 - Reorder `toList` in `ListZipper` to resolve test dependency issue