### PR TITLE
`Mondad.(<**>)` precedence

### DIFF
--- a/src/Course/Monad.hs
+++ b/src/Course/Monad.hs
@@ -27,47 +27,6 @@ class Applicative f => Monad f where
 
 infixr 1 =<<
 
--- | Witness that all things with (=<<) and (<$>) also have (<*>).
---
--- >>> ExactlyOne (+10) <**> ExactlyOne 8
--- ExactlyOne 18
---
--- >>> (+1) :. (*2) :. Nil <**> 1 :. 2 :. 3 :. Nil
--- [2,3,4,2,4,6]
---
--- >>> Full (+8) <**> Full 7
--- Full 15
---
--- >>> Empty <**> Full 7
--- Empty
---
--- >>> Full (+8) <**> Empty
--- Empty
---
--- >>> ((+) <**> (+10)) 3
--- 16
---
--- >>> ((+) <**> (+5)) 3
--- 11
---
--- >>> ((+) <**> (+5)) 1
--- 7
---
--- >>> ((*) <**> (+10)) 3
--- 39
---
--- >>> ((*) <**> (+2)) 3
--- 15
-(<**>) ::
-  Monad f =>
-  f (a -> b)
-  -> f a
-  -> f b
-(<**>) =
-  error "todo: Course.Monad#(<**>)"
-
-infixl 4 <**>
-
 -- | Binds a function on the ExactlyOne monad.
 --
 -- >>> (\x -> ExactlyOne(x+1)) =<< ExactlyOne 2
@@ -115,6 +74,47 @@ instance Monad ((->) t) where
     -> ((->) t b)
   (=<<) =
     error "todo: Course.Monad (=<<)#instance ((->) t)"
+
+-- | Witness that all things with (=<<) and (<$>) also have (<*>).
+--
+-- >>> ExactlyOne (+10) <**> ExactlyOne 8
+-- ExactlyOne 18
+--
+-- >>> (+1) :. (*2) :. Nil <**> 1 :. 2 :. 3 :. Nil
+-- [2,3,4,2,4,6]
+--
+-- >>> Full (+8) <**> Full 7
+-- Full 15
+--
+-- >>> Empty <**> Full 7
+-- Empty
+--
+-- >>> Full (+8) <**> Empty
+-- Empty
+--
+-- >>> ((+) <**> (+10)) 3
+-- 16
+--
+-- >>> ((+) <**> (+5)) 3
+-- 11
+--
+-- >>> ((+) <**> (+5)) 1
+-- 7
+--
+-- >>> ((*) <**> (+10)) 3
+-- 39
+--
+-- >>> ((*) <**> (+2)) 3
+-- 15
+(<**>) ::
+  Monad f =>
+  f (a -> b)
+  -> f a
+  -> f b
+(<**>) =
+  error "todo: Course.Monad#(<**>)"
+
+infixl 4 <**>
 
 -- | Flattens a combined structure to a single structure.
 --

--- a/test/Course/MonadTest.hs
+++ b/test/Course/MonadTest.hs
@@ -15,15 +15,35 @@ import           Course.Optional   (Optional (..))
 test_Monad :: TestTree
 test_Monad =
   testGroup "Monad" [
-    appTest
-  , bindExactlyOneTest
+    bindExactlyOneTest
   , bindListTest
   , bindOptionalTest
   , bindReaderTest
+  , appTest
   , joinTest
   , bindFlippedTest
   , kleisliCompositionTest
   ]
+
+bindExactlyOneTest :: TestTree
+bindExactlyOneTest =
+  testCase "(=<<) for ExactlyOne" $
+    ((\x -> ExactlyOne(x+1)) =<< ExactlyOne 2) @?= ExactlyOne 3
+
+bindListTest :: TestTree
+bindListTest =
+  testCase "(=<<) for List" $
+    ((\n -> n :. n :. Nil) =<< (1 :. 2 :. 3 :. Nil)) @?= (1:.1:.2:.2:.3:.3:.Nil)
+
+bindOptionalTest :: TestTree
+bindOptionalTest =
+  testCase "(=<<) for Optional" $
+    ((\n -> Full (n + n)) =<< Full 7) @?= Full 14
+
+bindReaderTest :: TestTree
+bindReaderTest =
+  testCase "(=<<) for (->)" $
+    ((*) =<< (+10)) 7 @?= 119
 
 appTest :: TestTree
 appTest =
@@ -49,26 +69,6 @@ appTest =
   , testCase "(->) 5" $
       ((*) <**> (+2)) 3 @?= 15
   ]
-
-bindExactlyOneTest :: TestTree
-bindExactlyOneTest =
-  testCase "(=<<) for ExactlyOne" $
-    ((\x -> ExactlyOne(x+1)) =<< ExactlyOne 2) @?= ExactlyOne 3
-
-bindListTest :: TestTree
-bindListTest =
-  testCase "(=<<) for List" $
-    ((\n -> n :. n :. Nil) =<< (1 :. 2 :. 3 :. Nil)) @?= (1:.1:.2:.2:.3:.3:.Nil)
-
-bindOptionalTest :: TestTree
-bindOptionalTest =
-  testCase "(=<<) for Optional" $
-    ((\n -> Full (n + n)) =<< Full 7) @?= Full 14
-
-bindReaderTest :: TestTree
-bindReaderTest =
-  testCase "(=<<) for (->)" $
-    ((*) =<< (+10)) 7 @?= 119
 
 joinTest :: TestTree
 joinTest =


### PR DESCRIPTION
Moving the `(<**>)` exercise in Monad below its dependencies means tests for each exercise will pass as students progress.