### PR TITLE
add ListZipperTest test to TastyLoader

### DIFF
--- a/course.cabal
+++ b/course.cabal
@@ -92,6 +92,7 @@ test-suite            tasty
                       Course.Gens
                       Course.JsonParserTest
                       Course.ListTest
+                      Course.ListZipperTest
                       Course.MonadTest
                       Course.OptionalTest
                       Course.StateTest

--- a/test/TastyLoader.hs
+++ b/test/TastyLoader.hs
@@ -5,6 +5,7 @@ import Course.ExtendTest (test_Extend)
 import Course.FunctorTest (test_Functor)
 import Course.JsonParserTest (test_JsonParser)
 import Course.ListTest (test_List)
+import Course.ListZipperTest (test_ListZipper)
 import Course.MonadTest (test_Monad)
 import Course.OptionalTest (test_Optional)
 import Course.StateTest (test_State)
@@ -27,6 +28,7 @@ tests =
   , test_Validation
   , test_Extend
   , test_Comonad
+  , test_ListZipper
   , test_JsonParser
   ]
 


### PR DESCRIPTION
The new ListZipper tests don't get discovered by tasty because they weren't added to TastyLoader.hs. This commit fixes that.