### PR TITLE
Listzipper test typos

### DIFF
--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -453,7 +453,7 @@ traversableTest =
 traversableMaybeTest :: TestTree
 traversableMaybeTest =
   testGroup "Traversable (MaybeListZipper)" [
-    testCase "IsNotZ" $ traverse id IsNotZ @?= (Empty :: Optional (MaybeListZipper Integer))
+    testCase "IsNotZ" $ traverse id IsNotZ @?= (Full IsNotZ :: Optional (MaybeListZipper Integer))
   , testProperty "IsZ Full" $
       forAllListZipper (\z -> traverse id (Full <$> IsZ z) == Full (IsZ z))
   ]

--- a/test/Course/ListZipperTest.hs
+++ b/test/Course/ListZipperTest.hs
@@ -355,7 +355,7 @@ deletePullRightTest :: TestTree
 deletePullRightTest =
   testGroup "deletePullRight" [
     testCase "non-empty rights" $ deletePullRight (zipper [3,2,1] 4 [5,6,7]) @?= IsZ (zipper [3,2,1] 5 [6,7])
-  , testCase "empty rights" $ deletePullLeft (zipper [3,2,1] 4 []) @?= IsNotZ
+  , testCase "empty rights" $ deletePullRight (zipper [3,2,1] 4 []) @?= IsNotZ
   ]
 
 insertPushLeftTest :: TestTree


### PR DESCRIPTION
Fixing two tests. The first is a straightforward fix that is an obvious typo. The latter is a semantic change, that `traverse id IsNotZ = pure IsNotZ`, which will be `Full IsNotZ` in the case of `traverse (id @(Optional (MaybeListZipper Integer))`. This also jives with the doctest example of

```
>>> traverse id IsNotZ
><
```

I might be wrong though so let me know.
