### PR TITLE
Removes Course.List#produce answer

### DIFF
--- a/src/Course/List.hs
+++ b/src/Course/List.hs
@@ -316,7 +316,8 @@ produce ::
   (a -> a)
   -> a
   -> List a
-produce f x = x :. produce f (f x)
+produce =
+  error "todo: Course.List#produce"
 
 -- | Do anything other than reverse a list.
 -- Is it even possible?


### PR DESCRIPTION
The answer for the `produce` function was left in. This pull request removes it. 