### PR TITLE
Add Stack.yaml as this code is broken for newer GHC

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -69,7 +69,7 @@ however, your first post might be moderated. This is simply to prevent spam.
 instead. [Instructions](ops/README.md) for automatically building a virtual machine are
 available in this repository for your convenience.
 
-1. Install the Glasgow Haskell Compiler (GHC) version 7.10 or higher.
+1. Install the Glasgow Haskell Compiler (GHC) version 8.0.2.
 
 2. Change to the directory containing this document.
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+resolver: lts-9.21
+
+packages:
+- .
+- projects/NetworkServer/haskell


### PR DESCRIPTION
Seems like this would break whenever Nix upgrades to a newer GHC version. Might be wise to specify the GHC version intended in the Nix expressions.