### PR TITLE
Add custom-setup stanza

### DIFF
--- a/projects/NetworkServer/haskell/network-server.cabal
+++ b/projects/NetworkServer/haskell/network-server.cabal
@@ -13,6 +13,9 @@ bug-reports:        https://github.com/data61/fp-course/issues
 cabal-version:      >= 1.10
 build-type:         Custom
 
+custom-setup
+  setup-depends:    Cabal >= 1.24 && < 2
+
 source-repository   head
   type:             git
   location:         git@github.com:data61/fp-course.git


### PR DESCRIPTION
The Setup.lhs file is incompatible with newer versions of the Cabal
library. This change adds the appropriate custom-setup stanza to
indicate compatibility with Cabal 1.24.