### PR TITLE
Add boundary test (length = 4) for lengthGT4

### DIFF
--- a/test/Course/ListTest.hs
+++ b/test/Course/ListTest.hs
@@ -183,6 +183,8 @@ lengthGT4Test =
   testGroup "lengthGT4" [
     testCase "list of length 3" $
       lengthGT4 (1 :. 3 :. 5 :. Nil) @?= False
+  , testCase "list of length 4" $
+      lengthGT4 (1 :. 2 :. 3 :. 4 :. Nil) @?= False
   , testCase "empty list" $
       lengthGT4 Nil @?= False
   , testCase "list of length 5" $


### PR DESCRIPTION
A couple of colleagues ending up having implementations that returned `True` for lists of length 4. Just added an extra test for this case.