### PR TITLE
Move list and list1 below digit, since digit is used in their tests

### DIFF
--- a/src/Course/Parser.hs
+++ b/src/Course/Parser.hs
@@ -216,52 +216,6 @@ instance Applicative Parser where
   (<*>) =
     error "todo: Course.Parser (<*>)#instance Parser"
 
--- | Return a parser that continues producing a list of values from the given parser.
---
--- /Tip:/ Use @list1@, @pure@ and @(|||)@.
---
--- >>> parse (list character) ""
--- Result >< ""
---
--- >>> parse (list digit) "123abc"
--- Result >abc< "123"
---
--- >>> parse (list digit) "abc"
--- Result >abc< ""
---
--- >>> parse (list character) "abc"
--- Result >< "abc"
---
--- >>> parse (list (character *> valueParser 'v')) "abc"
--- Result >< "vvv"
---
--- >>> parse (list (character *> valueParser 'v')) ""
--- Result >< ""
-list ::
-  Parser a
-  -> Parser (List a)
-list =
-  error "todo: Course.Parser#list"
-
--- | Return a parser that produces at least one value from the given parser then
--- continues producing a list of values from the given parser (to ultimately produce a non-empty list).
---
--- /Tip:/ Use @(=<<)@, @list@ and @pure@.
---
--- >>> parse (list1 (character)) "abc"
--- Result >< "abc"
---
--- >>> parse (list1 (character *> valueParser 'v')) "abc"
--- Result >< "vvv"
---
--- >>> isErrorResult (parse (list1 (character *> valueParser 'v')) "")
--- True
-list1 ::
-  Parser a
-  -> Parser (List a)
-list1 =
-  error "todo: Course.Parser#list1"
-
 -- | Return a parser that produces a character but fails if
 --
 --   * The input is empty.
@@ -317,6 +271,52 @@ space ::
   Parser Char
 space =
   error "todo: Course.Parser#space"
+
+-- | Return a parser that continues producing a list of values from the given parser.
+--
+-- /Tip:/ Use @list1@, @pure@ and @(|||)@.
+--
+-- >>> parse (list character) ""
+-- Result >< ""
+--
+-- >>> parse (list digit) "123abc"
+-- Result >abc< "123"
+--
+-- >>> parse (list digit) "abc"
+-- Result >abc< ""
+--
+-- >>> parse (list character) "abc"
+-- Result >< "abc"
+--
+-- >>> parse (list (character *> valueParser 'v')) "abc"
+-- Result >< "vvv"
+--
+-- >>> parse (list (character *> valueParser 'v')) ""
+-- Result >< ""
+list ::
+  Parser a
+  -> Parser (List a)
+list =
+  error "todo: Course.Parser#list"
+
+-- | Return a parser that produces at least one value from the given parser then
+-- continues producing a list of values from the given parser (to ultimately produce a non-empty list).
+--
+-- /Tip:/ Use @(=<<)@, @list@ and @pure@.
+--
+-- >>> parse (list1 (character)) "abc"
+-- Result >< "abc"
+--
+-- >>> parse (list1 (character *> valueParser 'v')) "abc"
+-- Result >< "vvv"
+--
+-- >>> isErrorResult (parse (list1 (character *> valueParser 'v')) "")
+-- True
+list1 ::
+  Parser a
+  -> Parser (List a)
+list1 =
+  error "todo: Course.Parser#list1"
 
 -- | Return a parser that produces one or more space characters
 -- (consuming until the first non-space) but fails if


### PR DESCRIPTION
closes #305 

The only thing I dislike about this is that it splits up `space` and `spaces1`, but other than that, I think this is a better order.