### PR TITLE
Fix typo ('two'=>'three') in Traversable laws

### DIFF
--- a/src/Course/Traversable.hs
+++ b/src/Course/Traversable.hs
@@ -12,7 +12,7 @@ import Course.ExactlyOne
 import Course.Optional
 import Course.Compose
 
--- | All instances of the `Traversable` type-class must satisfy two laws. These
+-- | All instances of the `Traversable` type-class must satisfy three laws. These
 -- laws are not checked by the compiler. These laws are given as:
 --
 -- * The law of naturality


### PR DESCRIPTION
The comment that precedes the Traversable type class definition declares there are two laws, but then goes on to define three (naturality, identity, composition).

Typeclassopedia does suggest that identity and composition are the traversable laws and that naturality follows if you are dealing with applicatives. But I definitely don't know enough to assess the truth of that claim. 
(ref: https://wiki.haskell.org/Typeclassopedia#Laws_7)

Either way the current comment may cause confusion (at least it did for me)