### PR TITLE
ignoring cabal new-test artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ cabal-dev
 .cabal-sandbox
 cabal.sandbox.config
 cabal.project.local
+.ghc.environment.*
 
 # Haskell Program Coverage
 /.hpc


### PR DESCRIPTION
ignore `cabal new-test` created env file

https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/packages.html#package-environments