### PR TITLE
List.hs : replace fold with helper function

### DIFF
--- a/src/Course/List.hs
+++ b/src/Course/List.hs
@@ -40,7 +40,7 @@ data List t =
 infixr 5 :.
 
 instance Show t => Show (List t) where
-  show = show . foldRight (:) []
+  show = show . hlist
 
 -- The list of integers from zero to infinity.
 infinity ::


### PR DESCRIPTION
There are two helper function for list conversion provided. Better use them for consistency.  

```
hlist ::  List a  -> [a]
listh ::  [a]  -> List a
```