### PR TITLE
Remove or suppressed unused imports warnings

### DIFF
--- a/test/Course/ComonadTest.hs
+++ b/test/Course/ComonadTest.hs
@@ -14,8 +14,6 @@ module Course.ComonadTest
   )
   where
 
-import           Data.String       (fromString)
-
 import           Test.Course.Mini  (courseTest)
 import           Test.Mini         (MiniTestTree, testCase, testGroup, (@?=))
 

--- a/test/Course/ParserTest.hs
+++ b/test/Course/ParserTest.hs
@@ -44,7 +44,7 @@ import           Course.Core
 import           Course.Functor     ((<$>))
 import           Course.List        (List ((:.), Nil))
 import           Course.Monad       ((=<<))
-import           Course.Optional    (Optional (Empty, Full))
+import           Course.Optional    (Optional (Full))
 import           Course.Parser
 import           Course.Person      (Person (Person))
 

--- a/test/Course/StateTest.hs
+++ b/test/Course/StateTest.hs
@@ -37,7 +37,7 @@ import           Course.List        (List (..), filter, flatMap, hlist, length,
                                      listh, span, (++))
 import           Course.Monad
 import           Course.Optional    (Optional (Empty, Full))
-import           Course.State       (State (State), distinct, eval, exec, findM,
+import           Course.State       (State (State), distinct, findM,
                                      firstRepeat, get, isHappy, put, runState)
 
 test_State :: MiniTestTree

--- a/test/Course/TraversableTest.hs
+++ b/test/Course/TraversableTest.hs
@@ -10,7 +10,7 @@ import           Course.Compose     (Compose (Compose))
 import           Course.Core
 import           Course.ExactlyOne  (ExactlyOne (ExactlyOne))
 import           Course.Functor
-import           Course.List        (List ((:.), Nil), listh)
+import           Course.List        (List (Nil), listh)
 import           Course.Optional    (Optional (Empty, Full))
 import           Course.Traversable
 

--- a/test/Test/Course/Mini.hs
+++ b/test/Test/Course/Mini.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE ImplicitPrelude       #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 
 module Test.Course.Mini where
 

--- a/test/Test/Mini.hs
+++ b/test/Test/Mini.hs
@@ -11,7 +11,7 @@
 -- module with a type and instance for running the test suite with Tasty.
 module Test.Mini where
 
-import           Data.String (IsString, fromString)
+import           Data.String (IsString)
 
 type MiniTestTree =
   forall name assertion t g.

--- a/test/TestLoader.hs
+++ b/test/TestLoader.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 
 module TestLoader
   ( Optional.test_Optional


### PR DESCRIPTION
Follow the precendent use of `OPTIONS_GHC -fno-warn-unused-imports` in
TastyLoader.

This resolves the following compilation warnings:

    test/Test/Mini.hs:14:1: warning: [-Wunused-imports]
        The import of ‘fromString’ from module ‘Data.String’ is redundant
       |
    14 | import           Data.String (IsString, fromString)
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    test/Test/Course/Mini.hs:15:1: warning: [-Wunused-imports]
        The import of ‘Data.String’ is redundant
          except perhaps to import instances from ‘Data.String’
        To import instances alone, use: import Data.String()
       |
    15 | import           Data.String       (fromString)
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    test/Course/TraversableTest.hs:13:1: warning: [-Wunused-imports]
        The import of ‘:.’ from module ‘Course.List’ is redundant
       |
    13 | import           Course.List        (List ((:.), Nil), listh)
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    test/Course/ParserTest.hs:47:1: warning: [-Wunused-imports]
        The import of ‘Empty’ from module ‘Course.Optional’ is redundant
       |
    47 | import           Course.Optional    (Optional (Empty, Full))
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    test/Course/StateTest.hs:40:1: warning: [-Wunused-imports]
        The import of ‘eval, exec’ from module ‘Course.State’ is redundant
       |
    40 | import           Course.State       (State (State), distinct, eval, exec, findM,
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...

    test/Course/ComonadTest.hs:17:1: warning: [-Wunused-imports]
        The import of ‘Data.String’ is redundant
          except perhaps to import instances from ‘Data.String’
        To import instances alone, use: import Data.String()
       |
    17 | import           Data.String       (fromString)
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    test/TestLoader.hs:44:1: warning: [-Wunused-imports]
        The import of ‘Data.String’ is redundant
          except perhaps to import instances from ‘Data.String’
        To import instances alone, use: import Data.String()
       |
    44 | import           Data.String            (fromString)
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
