### PR TITLE
Pin nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,24 +9,7 @@ let
                        then pkgs.haskellPackages
                        else pkgs.haskell.packages.${compiler};
 
-  sources = {
-    tasty = pkgs.fetchFromGitHub {
-      owner = "feuerbach";
-      repo = "tasty";
-      rev = "core-1.1.0.1";
-      sha256 = "03fcc75l5mrn5dwh6xix5ggn0qkp8kj7gzamb6n2m42ir6j7x60l";
-    };
-  };
-
-  modifiedHaskellPackages = haskellPackages.override {
-    overrides = self: super: {
-      tasty = super.callCabal2nix "tasty" "${sources.tasty}/core" {};
-      tasty-hunit = super.callCabal2nix "tasty" "${sources.tasty}/hunit" {};
-      tasty-quickcheck = super.callCabal2nix "tasty" "${sources.tasty}/quickcheck" {};
-    };
-  };
-
-  fp-course = modifiedHaskellPackages.callPackage ./fp-course.nix {};
+  fp-course = haskellPackages.callPackage ./fp-course.nix {};
   modified-fp-course = pkgs.haskell.lib.overrideCabal fp-course (drv: {
     # Dodgy fun times, make sure that
     # - the tests compile

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,6 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "default" }:
+{ nixpkgs ? import ./nix/nixpkgs.nix
+, compiler ? "default"
+}:
 
 let
   inherit (nixpkgs) pkgs;

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,7 +1,7 @@
 import (builtins.fetchGit {
   # Descriptive name to make the store path easier to identify
-  name = "nixos-18.09-2019-04-08";
-  url = https://github.com/nixos/nixpkgs;
-  # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-18.09`
-  rev = "222950952f15f6b1e9f036b80440b597f23e652d";
+  name = "nixos-unstable-2019-04-08";
+  url = https://github.com/nixos/nixpkgs/;
+  # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
+  rev = "acbdaa569f4ee387386ebe1b9e60b9f95b4ab21b";
 }) {}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,7 @@
+import (builtins.fetchGit {
+  # Descriptive name to make the store path easier to identify
+  name = "nixos-18.09-2019-04-08";
+  url = https://github.com/nixos/nixpkgs;
+  # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-18.09`
+  rev = "222950952f15f6b1e9f036b80440b597f23e652d";
+}) {}

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,6 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "default"}:
+{ nixpkgs ? import ./nix/nixpkgs.nix
+, compiler ? "default"
+}:
 let
   inherit (nixpkgs) pkgs;
   drv = import ./default.nix { inherit nixpkgs compiler; };


### PR DESCRIPTION
Pins `nixpkgs` to latest `nixos-unstable`. Overrides are also removed, as the `tasty` version being used doesn't compile with `ghc-8.6`, which comes with our pinned `nixpkgs`. Other overrides don't seem necessary now either.