### PR TITLE
Adding test that Parser Applicative runs in right order

### DIFF
--- a/test/Course/ParserTest.hs
+++ b/test/Course/ParserTest.hs
@@ -149,6 +149,8 @@ applicativeTest =
         parse (pure toUpper <*> valueParser 'a') "xyz" @?= Result "xyz" 'A'
     , testCase "pure show <*>" $
         parse (pure show <*> valueParser 599) "xyz" @?= Result "xyz" "599"
+    , testCase "append character <*>" $
+        parse (((\a b -> a :. b :. Nil) <$> character) <*> character) "abxyz" @?= Result "xyz" "ab"
   ]
 
 satisfyTest :: MiniTestTree


### PR DESCRIPTION
You can implement Parser Applicative such that it passes the existing tests but runs in reverse order
```
instance Applicative Parser where
(<*>) pab pa = (\a -> (\f -> f a) <$> pab) =<< pa
```
Gets caught at sequence in the same file, but would be good to catch it earlier rather than needing to backtrack after realising. This test catches it.