### PR TITLE
Exponential notation is optional in JSON parser

### DIFF
--- a/src/Course/JsonParser.hs
+++ b/src/Course/JsonParser.hs
@@ -119,6 +119,10 @@ jsonString =
 --
 -- /Tip:/ Use @readFloats@.
 --
+-- /Optional:/ As an extra challenge, you may wish to support exponential notation
+-- as defined on http://json.org/
+-- This is not required.
+--
 -- >>> parse jsonNumber "234"
 -- Result >< 234 % 1
 --


### PR DESCRIPTION
closes #329