### PR TITLE
Having bindings on `produce` means List.hs won't compile when reloaded.

### DIFF
--- a/src/Course/List.hs
+++ b/src/Course/List.hs
@@ -314,7 +314,7 @@ produce ::
   (a -> a)
   -> a
   -> List a
-produce f x =
+produce =
   error "todo: Course.List#produce"
 
 -- | Do anything other than reverse a list.


### PR DESCRIPTION
Seems like some stray characters are in List.hs's `produce` implementation. 