### PR TITLE
Bindings prevent compiling the empty "error" case in (??)

### DIFF
--- a/src/Course/Functor.hs
+++ b/src/Course/Functor.hs
@@ -124,7 +124,7 @@ instance Functor ((->) t) where
   k (a -> b)
   -> a
   -> k b
-(??) ff a =
+(??) =
   error "todo: Course.Functor#(??)"
 
 infixl 1 ??


### PR DESCRIPTION
These probably got saved accidentally by someone testing them. 